### PR TITLE
Agregar deploy continuo en workflow de GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,18 @@ name: Entrega Continua - Deploy
 
 on:
   workflow_run:
-    workflows: ["Integración Continua - Eventhub"]  # nombre exacto del workflow CI
+    workflows: ["Integración Continua - Eventhub"]
     types:
       - completed
+  push:
+    branches:
+      - main
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout del código
@@ -22,19 +27,21 @@ jobs:
 
       - name: Construir imagen Docker
         run: |
-          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/eventhub:${{ github.ref_name }}
+          IMAGE_TAG=${{ github.ref_name || 'main' }}
+          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/eventhub:$IMAGE_TAG
           docker build -t $IMAGE_NAME .
 
       - name: Publicar imagen Docker en DockerHub
         run: |
-          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/eventhub:${{ github.ref_name }}
+          IMAGE_TAG=${{ github.ref_name || 'main' }}
+          IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/eventhub:$IMAGE_TAG
           docker push $IMAGE_NAME
 
       - name: Deploy en Render
         env:
           RENDER_SERVICE_ID: ${{ secrets.RENDER_SERVICE_ID }}
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/eventhub:${{ github.ref_name }}
+          IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/eventhub:${{ github.ref_name || 'main' }}
         run: |
           curl -X POST https://api.render.com/v1/services/${RENDER_SERVICE_ID}/deploys \
             -H "Authorization: Bearer $RENDER_API_KEY" \


### PR DESCRIPTION
Se implementó el workflow para entrega continua que realiza el deploy automático al mergear cualquier Pull Request hacia la rama main o cuando se hacen pushes directos a main.

Cambios realizados:

Modificación del workflow de despliegue para activar el deploy tanto en eventos workflow_run exitosos como en push a main.

Ajuste en el tagging de la imagen Docker para usar correctamente el nombre de la rama o main por defecto.

Configuración para publicar la imagen Docker y hacer deploy en Render automáticamente.

Este cambio permite acelerar el proceso de entrega y mantener el entorno de producción siempre actualizado tras la integración en main.